### PR TITLE
fix: Prevent server-side Firebase initialization during build

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -48,6 +48,7 @@ export default function LoginPage() {
   }, []);
 
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       if (user) {
         toast({
@@ -75,6 +76,7 @@ export default function LoginPage() {
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!auth) return;
     setLoading(true);
     try {
       await signInWithEmailAndPassword(auth, email, password);
@@ -91,6 +93,7 @@ export default function LoginPage() {
   };
 
   const handleGoogleSignIn = async () => {
+    if (!auth || !googleProvider) return;
     setGoogleLoading(true);
     try {
         await signInWithPopup(auth, googleProvider);
@@ -109,6 +112,7 @@ export default function LoginPage() {
   };
 
   const handleAnonymousSignIn = async () => {
+    if (!auth) return;
     setAnonymousLoading(true);
     try {
         await signInAnonymously(auth);
@@ -126,6 +130,7 @@ export default function LoginPage() {
 
   const handlePhoneSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!auth) return;
     setPhoneLoading(true);
     const appVerifier = setupRecaptcha();
     if (!appVerifier) {

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -29,7 +29,7 @@ import { bn, enUS } from 'date-fns/locale';
 import { useI18n } from "@/context/i18n";
 
 async function getUserProfile(userId: string): Promise<User | null> {
-  if (!userId) return null;
+  if (!userId || !db) return null;
   const userDocRef = doc(db, "users", userId);
   const userDoc = await getDoc(userDocRef);
   if (userDoc.exists()) {
@@ -51,6 +51,7 @@ export default function MessagesPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setCurrentUser(user);
     });
@@ -58,7 +59,7 @@ export default function MessagesPage() {
   }, []);
 
   useEffect(() => {
-    if (!currentUser) return;
+    if (!currentUser || !db) return;
     setLoading(true);
     const q = query(collection(db, "conversations"), where("participants", "array-contains", currentUser.uid), orderBy("lastMessageTimestamp", "desc"));
     
@@ -87,7 +88,7 @@ export default function MessagesPage() {
   }, [currentUser]);
 
   useEffect(() => {
-    if (selectedConversation) {
+    if (selectedConversation && db) {
       setMsgLoading(true);
       const q = query(collection(db, "conversations", selectedConversation.id, "messages"), orderBy("timestamp", "asc"));
       const unsubscribe = onSnapshot(q, (querySnapshot) => {
@@ -108,7 +109,7 @@ export default function MessagesPage() {
 
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newMessage.trim() || !currentUser || !selectedConversation || sending) return;
+    if (!newMessage.trim() || !currentUser || !selectedConversation || sending || !db) return;
 
     setSending(true);
     const content = newMessage;

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -17,7 +17,7 @@ import { useRouter } from 'next/navigation';
 import { useI18n } from '@/context/i18n';
 
 async function getUserProfile(userId: string): Promise<User | null> {
-    if (!userId) return null;
+    if (!userId || !db) return null;
     const userDocRef = doc(db, "users", userId);
     const userDoc = await getDoc(userDocRef);
     if (userDoc.exists()) {
@@ -75,6 +75,7 @@ export default function NotificationsPage() {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
+        if (!auth) return;
         const unsubscribe = onAuthStateChanged(auth, (user) => {
             if (user) {
                 setCurrentUser(user);
@@ -86,7 +87,7 @@ export default function NotificationsPage() {
     }, [router]);
 
     useEffect(() => {
-        if (!currentUser) return;
+        if (!currentUser || !db) return;
         setLoading(true);
         const q = query(
             collection(db, "notifications"),
@@ -111,6 +112,7 @@ export default function NotificationsPage() {
     }, [currentUser]);
 
     const handleNotificationClick = async (notification: NotificationType) => {
+        if (!db) return;
         if (!notification.read) {
             await updateDoc(doc(db, "notifications", notification.id), { read: true });
         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ import { Loader2 } from 'lucide-react';
 import { useI18n } from '@/context/i18n';
 
 async function getUserProfile(userId: string): Promise<AppUser | null> {
-  if (!userId) return null;
+  if (!userId || !db) return null;
   const userDocRef = doc(db, "users", userId);
   const userDoc = await getDoc(userDocRef);
   if (userDoc.exists()) {
@@ -26,7 +26,8 @@ async function getUserProfile(userId: string): Promise<AppUser | null> {
   return null;
 }
 
-async function createUserProfile(firebaseUser: FirebaseUser): Promise<AppUser> {
+async function createUserProfile(firebaseUser: FirebaseUser): Promise<AppUser | null> {
+    if (!db) return null;
     const isAnonymous = firebaseUser.isAnonymous;
     const newUser: AppUser = {
         id: firebaseUser.uid,
@@ -53,6 +54,7 @@ export default function Home() {
   const { t } = useI18n();
 
   const fetchPosts = useCallback(async () => {
+    if (!db) return;
     setPostsLoading(true);
     const postsQuery = query(collection(db, "posts"), orderBy("createdAt", "desc"), limit(20));
     const querySnapshot = await getDocs(postsQuery);
@@ -68,7 +70,7 @@ export default function Home() {
   }, []);
   
   const fetchSuggestedUsers = useCallback(async (currentUserId: string) => {
-    if (!currentUserId) return;
+    if (!currentUserId || !db) return;
     const usersQuery = query(
       collection(db, "users"), 
       where("id", "!=", currentUserId),
@@ -80,6 +82,7 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, async (fbUser) => {
       if (fbUser) {
         setFirebaseUser(fbUser);

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -13,7 +13,7 @@ import { Button } from '@/components/ui/button';
 import { useI18n } from '@/context/i18n';
 
 async function getUserProfile(userId: string): Promise<User | null> {
-    if (!userId) return null;
+    if (!userId || !db) return null;
     const userDocRef = doc(db, "users", userId);
     const userDoc = await getDoc(userDocRef);
     if (userDoc.exists()) {
@@ -27,7 +27,7 @@ export default function PostPage() {
     const router = useRouter();
     const { t } = useI18n();
     const postId = params.id as string;
-    const [user] = useAuthState(auth);
+    const [user] = useAuthState(auth!);
     const [post, setPost] = useState<Post | null>(null);
     const [loading, setLoading] = useState(true);
 
@@ -35,6 +35,7 @@ export default function PostPage() {
         if (!postId) return;
 
         const fetchPost = async () => {
+            if (!db) return;
             setLoading(true);
             const postRef = doc(db, "posts", postId);
             const postDoc = await getDoc(postRef);

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -34,6 +34,7 @@ export default function ProfilePage() {
   const [followLoading, setFollowLoading] = useState(false);
   
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, (user) => {
         setCurrentUser(user);
     });
@@ -41,7 +42,7 @@ export default function ProfilePage() {
   }, []);
   
   useEffect(() => {
-    if (!userId) return;
+    if (!userId || !db) return;
     setLoading(true);
     const unsub = onSnapshot(doc(db, "users", userId), (doc) => {
         if(doc.exists()){
@@ -56,7 +57,7 @@ export default function ProfilePage() {
 
 
   const fetchPosts = useCallback(async () => {
-    if(!user || !userId) return;
+    if(!user || !userId || !db) return;
     setPostsLoading(true);
     const postsQuery = query(
       collection(db, "posts"), 
@@ -83,7 +84,7 @@ export default function ProfilePage() {
   }, [user, fetchPosts]);
 
   useEffect(() => {
-    if (!currentUser || !user) return;
+    if (!currentUser || !user || !db) return;
     setFollowLoading(true);
     const followDocRef = doc(db, "follows", `${currentUser.uid}_${user.id}`);
     const unsubscribe = onSnapshot(followDocRef, (doc) => {
@@ -94,7 +95,7 @@ export default function ProfilePage() {
   }, [currentUser, user]);
 
   const handleFollowToggle = async () => {
-    if (!currentUser || !user || followLoading) return;
+    if (!currentUser || !user || followLoading || !db) return;
     setFollowLoading(true);
 
     const currentUserRef = doc(db, "users", currentUser.uid);
@@ -135,7 +136,7 @@ export default function ProfilePage() {
   };
 
   const handleSendMessage = async () => {
-    if (!currentUser || !user) return;
+    if (!currentUser || !user || !db) return;
 
     const conversationId = [currentUser.uid, user.id].sort().join('_');
     const conversationRef = doc(db, 'conversations', conversationId);

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -58,9 +58,14 @@ export default function EditProfilePage() {
    }, [t]);
 
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         setCurrentUser(user);
+        if (!db) {
+            setLoading(false);
+            return;
+        }
         const userDocRef = doc(db, "users", user.uid);
         const userDoc = await getDoc(userDocRef);
         if (userDoc.exists()) {
@@ -95,7 +100,7 @@ export default function EditProfilePage() {
   };
 
   const onSubmit: SubmitHandler<ProfileFormValues> = async (data) => {
-    if (!currentUser || !userProfile) return;
+    if (!currentUser || !userProfile || !storage || !db) return;
     setIsSubmitting(true);
     
     try {

--- a/src/app/search/search-component.tsx
+++ b/src/app/search/search-component.tsx
@@ -17,7 +17,7 @@ import { Button } from '@/components/ui/button';
 import { useI18n } from '@/context/i18n';
 
 async function getUserProfile(userId: string): Promise<User | null> {
-    if (!userId) return null;
+    if (!userId || !db) return null;
     const userDocRef = doc(db, "users", userId);
     const userDoc = await getDoc(userDocRef);
     if (userDoc.exists()) {
@@ -33,7 +33,7 @@ export function SearchComponent() {
     const [users, setUsers] = useState<User[]>([]);
     const [loading, setLoading] = useState(false);
     const [hasSearched, setHasSearched] = useState(false);
-    const [currentUser] = useAuthState(auth);
+    const [currentUser] = useAuthState(auth!);
     const { t } = useI18n();
 
     useEffect(() => {
@@ -44,6 +44,7 @@ export function SearchComponent() {
                 setHasSearched(false);
                 return;
             }
+            if (!db) return;
             setLoading(true);
             setHasSearched(true);
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -57,6 +57,7 @@ export default function SignupPage() {
   }, []);
 
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       if (user) {
         toast({
@@ -93,6 +94,7 @@ export default function SignupPage() {
       return;
     }
     setLoading(true);
+    if (!auth) return;
     try {
       await createUserWithEmailAndPassword(auth, email, password);
     } catch (error: any) {
@@ -108,6 +110,7 @@ export default function SignupPage() {
   };
 
   const handleGoogleSignIn = async () => {
+    if (!auth || !googleProvider) return;
     setGoogleLoading(true);
     try {
         await signInWithPopup(auth, googleProvider);
@@ -126,6 +129,7 @@ export default function SignupPage() {
   };
 
   const handleAnonymousSignIn = async () => {
+    if (!auth) return;
     setAnonymousLoading(true);
     try {
         await signInAnonymously(auth);
@@ -143,6 +147,7 @@ export default function SignupPage() {
 
   const handlePhoneSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!auth) return;
     setPhoneLoading(true);
     const appVerifier = setupRecaptcha();
     if (!appVerifier) {

--- a/src/components/comment-sheet.tsx
+++ b/src/components/comment-sheet.tsx
@@ -45,7 +45,7 @@ interface CommentSheetProps {
 }
 
 async function getUserProfile(userId: string): Promise<User | null> {
-    if (!userId) return null;
+    if (!userId || !db) return null;
     const userDocRef = doc(db, "users", userId);
     const userDoc = await getDoc(userDocRef);
     if (userDoc.exists()) {
@@ -55,7 +55,7 @@ async function getUserProfile(userId: string): Promise<User | null> {
 }
 
 export function CommentSheet({ postId, postContent, author, open, onOpenChange }: CommentSheetProps) {
-  const [user] = useAuthState(auth);
+  const [user] = useAuthState(auth!);
   const { toast } = useToast();
   const { t, locale } = useI18n();
   const [comments, setComments] = useState<Comment[]>([]);
@@ -64,7 +64,7 @@ export function CommentSheet({ postId, postContent, author, open, onOpenChange }
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !db) return;
     setLoading(true);
     const q = query(
       collection(db, "posts", postId, "comments"),
@@ -88,7 +88,7 @@ export function CommentSheet({ postId, postContent, author, open, onOpenChange }
 
   const handleAddComment = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newComment.trim() || !user || submitting || !author) return;
+    if (!newComment.trim() || !user || submitting || !author || !db) return;
 
     setSubmitting(true);
     

--- a/src/components/create-post.tsx
+++ b/src/components/create-post.tsx
@@ -115,6 +115,7 @@ export function CreatePost({ user, onPostCreated }: CreatePostProps) {
         });
         return;
     }
+    if (!db || !storage) return;
 
     setIsSubmitting(true);
     try {

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -20,6 +20,7 @@ export function MobileNav() {
   const [notificationCount, setNotificationCount] = useState(0);
 
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
       setUser(currentUser);
       setLoading(false);
@@ -28,7 +29,7 @@ export function MobileNav() {
   }, []);
 
   useEffect(() => {
-    if (!user) return;
+    if (!user || !db) return;
     const q = query(
         collection(db, "notifications"),
         where("recipientId", "==", user.uid),

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -46,7 +46,7 @@ export function PostCard({ post, user }: PostCardProps) {
   const [isCommentSheetOpen, setIsCommentSheetOpen] = useState(false);
 
   useEffect(() => {
-    if (!post.id) return;
+    if (!post.id || !db) return;
     const postRef = doc(db, "posts", post.id);
     const unsubscribe = onSnapshot(postRef, (doc) => {
         if(doc.exists()) {
@@ -60,7 +60,7 @@ export function PostCard({ post, user }: PostCardProps) {
   
   useEffect(() => {
     let unsubscribe: () => void;
-    if (user && post.id) {
+    if (user && post.id && db) {
       const likeDocRef = doc(db, "posts", post.id, "likes", user.uid);
       unsubscribe = onSnapshot(likeDocRef, (doc) => {
         setIsLiked(doc.exists());
@@ -72,7 +72,7 @@ export function PostCard({ post, user }: PostCardProps) {
   }, [user, post.id]);
 
   const handleLikeToggle = async () => {
-    if (!user || likeLoading || !post.id || !post.author) return;
+    if (!user || likeLoading || !post.id || !post.author || !db) return;
     setLikeLoading(true);
 
     const postRef = doc(db, "posts", post.id);

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -19,7 +19,7 @@ import { useI18n } from "@/context/i18n";
 import { LanguageSwitcher } from "./language-switcher";
 
 async function getUserProfile(userId: string): Promise<AppUser | null> {
-  if (!userId) return null;
+  if (!userId || !db) return null;
   const userDocRef = doc(db, "users", userId);
   const userDoc = await getDoc(userDocRef);
   if (userDoc.exists()) {
@@ -80,6 +80,7 @@ export function Sidebar() {
 
 
   useEffect(() => {
+    if (!auth) return;
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
       setFirebaseUser(currentUser);
       if (currentUser) {
@@ -94,7 +95,7 @@ export function Sidebar() {
   }, []);
 
   useEffect(() => {
-    if (!firebaseUser) return;
+    if (!firebaseUser || !db) return;
     const q = query(
         collection(db, "notifications"),
         where("recipientId", "==", firebaseUser.uid),
@@ -108,6 +109,7 @@ export function Sidebar() {
 
 
   const handleLogout = async () => {
+    if (!auth) return;
     try {
       await auth.signOut();
       router.push('/login');

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,9 +1,8 @@
-
 // Import the functions you need from the SDKs you need
-import { initializeApp, getApps, getApp } from "firebase/app";
-import { getAuth, GoogleAuthProvider, signInAnonymously, RecaptchaVerifier, signInWithPhoneNumber } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-import { getStorage } from "firebase/storage";
+import { initializeApp, getApps, getApp, FirebaseApp } from "firebase/app";
+import { getAuth, GoogleAuthProvider, signInAnonymously, RecaptchaVerifier, signInWithPhoneNumber, Auth } from "firebase/auth";
+import { getFirestore, Firestore } from "firebase/firestore";
+import { getStorage, FirebaseStorage } from "firebase/storage";
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
@@ -15,14 +14,26 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
 };
 
-// Initialize Firebase
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+let app: FirebaseApp | null = null;
+let auth: Auth | null = null;
+let db: Firestore | null = null;
+let storage: FirebaseStorage | null = null;
+let googleProvider: GoogleAuthProvider | null = null;
 
+if (typeof window !== 'undefined') {
+  if (getApps().length === 0) {
+    app = initializeApp(firebaseConfig);
+  } else {
+    app = getApp();
+  }
 
-const auth = getAuth(app);
-const db = getFirestore(app);
-const storage = getStorage(app);
-const googleProvider = new GoogleAuthProvider();
+  if (app) {
+    auth = getAuth(app);
+    db = getFirestore(app);
+    storage = getStorage(app);
+    googleProvider = new GoogleAuthProvider();
+  }
+}
 
 // Add this to the global window object
 declare global {
@@ -32,5 +43,3 @@ declare global {
 }
 
 export { app, auth, db, storage, googleProvider, signInAnonymously, RecaptchaVerifier, signInWithPhoneNumber };
-
-    


### PR DESCRIPTION
The build was failing with `FirebaseError: Error (auth/invalid-api-key)` because Firebase services were being initialized on the server-side during the build process, where the necessary environment variables were not available.

This change resolves the issue by wrapping the Firebase initialization logic in `src/lib/firebase.ts` within an `if (typeof window !== 'undefined')` block. This ensures that the Firebase SDK is only initialized in a browser environment.

Additionally, the resulting TypeScript errors have been fixed by adding null checks throughout the codebase where Firebase services are used. This improves runtime safety and ensures that Firebase services are not accessed before they are initialized.